### PR TITLE
chore(logging): made component name a dedicated type to prevent errors

### DIFF
--- a/internal/api/v1/projects.go
+++ b/internal/api/v1/projects.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang-malawi/qatarina/internal/config"
 	"github.com/golang-malawi/qatarina/internal/database/dbsqlc"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 	"github.com/golang-malawi/qatarina/internal/services"
 	"github.com/golang-malawi/qatarina/pkg/problemdetail"
@@ -85,7 +86,6 @@ func GetOneProject(projectService services.ProjectService) fiber.Handler {
 		return c.JSON(fiber.Map{
 			"project": schema.NewProjectResponse(project, nil),
 		})
-		return problemdetail.NotImplemented(c, "failed to get one Project")
 	}
 }
 
@@ -110,7 +110,7 @@ func GetProjectTestCases(testCaseService services.TestCaseService, logger loggin
 		}
 		testCases, err := testCaseService.FindAllByProjectID(context.Background(), projectID)
 		if err != nil {
-			logger.Error("api:projects", "failed to fetch test cases for project", "projectID", projectID, "error", err)
+			logger.Error(loggedmodule.ApiProjects, "failed to fetch test cases for project", "projectID", projectID, "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -141,7 +141,7 @@ func GetProjectTestPlans(testPlanService services.TestPlanService, logger loggin
 		}
 		testPlans, err := testPlanService.FindAllByProjectID(context.Background(), projectID)
 		if err != nil {
-			logger.Error("api:projects", "failed to fetch test cases for project", "projectID", projectID, "error", err)
+			logger.Error(loggedmodule.ApiProjects, "failed to fetch test cases for project", "projectID", projectID, "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -172,7 +172,7 @@ func GetProjectTestRuns(testRunService services.TestRunService, logger logging.L
 		}
 		testPlans, err := testRunService.FindAllByProjectID(context.Background(), projectID)
 		if err != nil {
-			logger.Error("api:projects", "failed to fetch test cases for project", "projectID", projectID, "error", err)
+			logger.Error(loggedmodule.ApiProjects, "failed to fetch test cases for project", "projectID", projectID, "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -227,7 +227,7 @@ func CreateProject(projectService services.ProjectService, testPlanService servi
 
 			_, err := testPlanService.Create(context.Background(), newDefaultTestPlan)
 			if err != nil {
-				logger.Error("projectsv1", "failed to create a default test plan for project", "projectID", project.ID, "error", err)
+				logger.Error(loggedmodule.ApiProjects, "failed to create a default test plan for project", "projectID", project.ID, "error", err)
 			}
 		}
 
@@ -316,7 +316,7 @@ func GetProjectTesters(projectService services.ProjectService, testerService ser
 		}
 		testers, err := testerService.FindByProjectID(context.Background(), int64(projectID))
 		if err != nil {
-			logger.Error("api:projects", "failed to fetch testers for project", "projectID", projectID, "error", err)
+			logger.Error(loggedmodule.ApiProjects, "failed to fetch testers for project", "projectID", projectID, "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to fetch testers")
 		}
 		return c.JSON(fiber.Map{
@@ -353,7 +353,7 @@ func AssignTesters(testerService services.TesterService, logger logging.Logger) 
 		}
 
 		if err := testerService.AssignBulk(context.Background(), projectID, &request); err != nil {
-			logger.Error("api:projects", "failed to assign testers to project", "projectID", projectID, "error", err)
+			logger.Error(loggedmodule.ApiProjects, "failed to assign testers to project", "projectID", projectID, "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to assign testers")
 		}
 

--- a/internal/api/v1/testcases.go
+++ b/internal/api/v1/testcases.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-malawi/qatarina/internal/common"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 	"github.com/golang-malawi/qatarina/internal/services"
 	"github.com/golang-malawi/qatarina/pkg/problemdetail"
@@ -101,13 +102,13 @@ func CreateTestCase(testCaseService services.TestCaseService, logger logging.Log
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-test-cases", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
 		_, err := testCaseService.Create(context.Background(), request)
 		if err != nil {
-			logger.Error("api-test-cases", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to process request", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -137,13 +138,13 @@ func BulkCreateTestCases(testCaseService services.TestCaseService, logger loggin
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-test-cases", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
 		_, err := testCaseService.BulkCreate(context.Background(), request)
 		if err != nil {
-			logger.Error("api-test-cases", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to process request", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -174,13 +175,13 @@ func UpdateTestCase(testCaseService services.TestCaseService, logger logging.Log
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-test-cases", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
 		_, err := testCaseService.Update(context.Background(), request)
 		if err != nil {
-			logger.Error("api-test-cases", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiTestCases, "failed to process request", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 

--- a/internal/api/v1/testplans.go
+++ b/internal/api/v1/testplans.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang-malawi/qatarina/internal/api/authutil"
 	"github.com/golang-malawi/qatarina/internal/common"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 	"github.com/golang-malawi/qatarina/internal/services"
 	"github.com/golang-malawi/qatarina/pkg/problemdetail"
@@ -97,7 +98,7 @@ func CreateTestPlan(testPlanService services.TestPlanService, logger logging.Log
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-test-cases", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiTestPlans, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
@@ -109,7 +110,7 @@ func CreateTestPlan(testPlanService services.TestPlanService, logger logging.Log
 
 		_, err := testPlanService.Create(context.Background(), request)
 		if err != nil {
-			logger.Error("api-test-cases", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiTestPlans, "failed to process request", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 
@@ -171,7 +172,7 @@ func AssignTestsToPlan(testPlanService services.TestPlanService, logger logging.
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-test-cases", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiTestPlans, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
@@ -182,7 +183,7 @@ func AssignTestsToPlan(testPlanService services.TestPlanService, logger logging.
 
 		_, err := testPlanService.AddTestCaseToPlan(context.Background(), request)
 		if err != nil {
-			logger.Error("api-test-cases", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiTestPlans, "failed to process request", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 

--- a/internal/api/v1/testruns.go
+++ b/internal/api/v1/testruns.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang-malawi/qatarina/internal/api/authutil"
 	"github.com/golang-malawi/qatarina/internal/common"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 	"github.com/golang-malawi/qatarina/internal/services"
 	"github.com/golang-malawi/qatarina/pkg/problemdetail"
@@ -160,12 +161,14 @@ func CommitTestRun(testRunService services.TestRunService, logger logging.Logger
 
 		testRunID := ctx.Params("testRunID", "")
 		if request.TestRunID != testRunID {
+			logger.Debug(loggedmodule.ApiTestRuns, "cannot to commit test-run with mismatching ids", "param", testRunID, "requestBodyID", request.TestRunID)
 			return problemdetail.BadRequest(ctx, "'test_run_id' in request body and parameter does not match")
 		}
 		request.UserID = authutil.GetAuthUserID(ctx)
 
 		testRun, err := testRunService.Commit(context.Background(), request)
 		if err != nil {
+			logger.Error(loggedmodule.ApiTestRuns, "failed to commit test-run results", "error", err)
 			return problemdetail.ServerErrorProblem(ctx, "failed to process request")
 		}
 		return ctx.JSON(fiber.Map{
@@ -184,6 +187,7 @@ func CommitBulkTestRun(testRunService services.TestRunService, logger logging.Lo
 		request.UserID = authutil.GetAuthUserID(ctx)
 		_, err = testRunService.CommitBulk(context.Background(), request)
 		if err != nil {
+			logger.Debug(loggedmodule.ApiTestRuns, "failed to commit bulk test results", "error", err)
 			return problemdetail.ServerErrorProblem(ctx, "failed to process request")
 		}
 		return ctx.JSON(fiber.Map{

--- a/internal/api/v1/users.go
+++ b/internal/api/v1/users.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-malawi/qatarina/internal/common"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 	"github.com/golang-malawi/qatarina/internal/services"
 	"github.com/golang-malawi/qatarina/pkg/problemdetail"
@@ -29,7 +30,7 @@ func ListUsers(userService services.UserService, logger logging.Logger) fiber.Ha
 	return func(c *fiber.Ctx) error {
 		users, err := userService.FindAll(context.Background())
 		if err != nil {
-			logger.Error("apiv1:users", "failed to load users", "error", err)
+			logger.Error(loggedmodule.ApiUsers, "failed to load users", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to load users")
 		}
 
@@ -94,7 +95,7 @@ func CreateUser(userService services.UserService, logger logging.Logger) fiber.H
 			if validationErrors {
 				return problemdetail.ValidationErrors(c, "invalid data in request", err)
 			}
-			logger.Error("api-users", "failed to parse request data", "error", err)
+			logger.Error(loggedmodule.ApiUsers, "failed to parse request data", "error", err)
 			return problemdetail.BadRequest(c, "failed to parse data in request")
 		}
 
@@ -103,7 +104,7 @@ func CreateUser(userService services.UserService, logger logging.Logger) fiber.H
 			if errors.Is(err, services.ErrEmailAlreadyInUse) {
 				return problemdetail.BadRequest(c, err.Error())
 			}
-			logger.Error("api-users", "failed to process request", "error", err)
+			logger.Error(loggedmodule.ApiUsers, "failed to create user account", "error", err)
 			return problemdetail.ServerErrorProblem(c, "failed to process request")
 		}
 

--- a/internal/logging/loggedmodule/loggedmodule.go
+++ b/internal/logging/loggedmodule/loggedmodule.go
@@ -1,0 +1,16 @@
+package loggedmodule
+
+type Name string
+
+const (
+	// API modules
+	ApiAuth      Name = "apiv1:auth"
+	ApiUsers     Name = "apiv1:users"
+	ApiTests     Name = "apiv1:tests"
+	ApiTestCases Name = "apiv1:test-cases"
+	ApiTestRuns  Name = "apiv1:test-runs"
+	ApiTesters   Name = "apiv1:testers"
+	ApiTestPlans Name = "apiv1:test-plans"
+	ApiProjects  Name = "apiv1:projects"
+	ApiSettings  Name = "apiv1:settings"
+)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 
 	"github.com/golang-malawi/qatarina/internal/config"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 )
 
 type Logger interface {
-	Debug(component, msg string, args ...any)
-	Info(component, msg string, args ...any)
-	Error(component, msg string, args ...any)
+	Debug(component loggedmodule.Name, msg string, args ...any)
+	Info(component loggedmodule.Name, msg string, args ...any)
+	Error(component loggedmodule.Name, msg string, args ...any)
 }
 
 type slogLogger struct {
@@ -22,7 +23,7 @@ type slogLogger struct {
 }
 
 // Debug implements Logger.
-func (l *slogLogger) Debug(component, msg string, args ...any) {
+func (l *slogLogger) Debug(component loggedmodule.Name, msg string, args ...any) {
 	if args == nil {
 		l.logger.Debug(msg, "component", component)
 		return
@@ -32,7 +33,7 @@ func (l *slogLogger) Debug(component, msg string, args ...any) {
 }
 
 // Error implements Logger.
-func (l *slogLogger) Error(component, msg string, args ...any) {
+func (l *slogLogger) Error(component loggedmodule.Name, msg string, args ...any) {
 	if args == nil {
 		l.logger.Error(msg, "component", component)
 		return
@@ -42,7 +43,7 @@ func (l *slogLogger) Error(component, msg string, args ...any) {
 }
 
 // Info implements Logger.
-func (l *slogLogger) Info(component, msg string, args ...any) {
+func (l *slogLogger) Info(component loggedmodule.Name, msg string, args ...any) {
 	if args == nil {
 		l.logger.Info(msg, "component", component)
 		return

--- a/internal/services/project.go
+++ b/internal/services/project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang-malawi/qatarina/internal/common"
 	"github.com/golang-malawi/qatarina/internal/database/dbsqlc"
 	"github.com/golang-malawi/qatarina/internal/logging"
+	"github.com/golang-malawi/qatarina/internal/logging/loggedmodule"
 	"github.com/golang-malawi/qatarina/internal/schema"
 )
 
@@ -19,14 +20,14 @@ type ProjectService interface {
 }
 
 type projectServiceImpl struct {
-	name   string
+	name   loggedmodule.Name
 	db     *dbsqlc.Queries
 	logger logging.Logger
 }
 
 func NewProjectService(db *dbsqlc.Queries, logger logging.Logger) ProjectService {
 	return &projectServiceImpl{
-		name:   "project-service",
+		name:   "projects-service",
 		db:     db,
 		logger: logger,
 	}


### PR DESCRIPTION
Developers would use different names for the same module when logging. Have changed the type of the component name on the logger to a dedicated type to help limit this issue and to make logging a bit more consistent
