### PR TITLE
fix:include project code during project creation

### DIFF
--- a/internal/database/dbsqlc/query.sql.go
+++ b/internal/database/dbsqlc/query.sql.go
@@ -375,19 +375,20 @@ func (q *Queries) CreatePage(ctx context.Context, arg CreatePageParams) (Page, e
 
 const createProject = `-- name: CreateProject :one
 INSERT INTO projects (
-    title, description, version, is_active, is_public, website_url,
+    title, code, description, version, is_active, is_public, website_url,
     github_url, trello_url, jira_url, monday_url,
     owner_user_id, created_at, updated_at, deleted_at
 )
 VALUES(
     $1, $2, $3, $4, $5, $6,
     $7, $8, $9, $10,
-    $11, $12, $13, $14
+    $11, $12, $13, $14, $15
 ) RETURNING id
 `
 
 type CreateProjectParams struct {
 	Title       string
+	Code        string
 	Description string
 	Version     sql.NullString
 	IsActive    sql.NullBool
@@ -406,6 +407,7 @@ type CreateProjectParams struct {
 func (q *Queries) CreateProject(ctx context.Context, arg CreateProjectParams) (int32, error) {
 	row := q.db.QueryRowContext(ctx, createProject,
 		arg.Title,
+		arg.Code,
 		arg.Description,
 		arg.Version,
 		arg.IsActive,

--- a/internal/services/project.go
+++ b/internal/services/project.go
@@ -45,6 +45,7 @@ func NewProjectService(db *dbsqlc.Queries, logger logging.Logger, moduleService 
 func (s *projectServiceImpl) Create(ctx context.Context, request *schema.NewProjectRequest) (*dbsqlc.Project, error) {
 	projectID, err := s.db.CreateProject(context.Background(), dbsqlc.CreateProjectParams{
 		Title:       request.Name,
+		Code:        request.Code,
 		Description: request.Description,
 		Version:     common.NullString(request.Version),
 		IsActive:    common.TrueNullBool(),

--- a/query.sql
+++ b/query.sql
@@ -82,14 +82,14 @@ DELETE FROM projects WHERE id = $1;
 
 -- name: CreateProject :one
 INSERT INTO projects (
-    title, description, version, is_active, is_public, website_url,
+    title, code, description, version, is_active, is_public, website_url,
     github_url, trello_url, jira_url, monday_url,
     owner_user_id, created_at, updated_at, deleted_at
 )
 VALUES(
     $1, $2, $3, $4, $5, $6,
     $7, $8, $9, $10,
-    $11, $12, $13, $14
+    $11, $12, $13, $14, $15
 ) RETURNING id;
 
 -- name: ListTestCases :many

--- a/ui/src/data/forms/project-schemas.ts
+++ b/ui/src/data/forms/project-schemas.ts
@@ -4,6 +4,7 @@ import { environmentSchema } from './environmentSchema';
 // Project creation schema
 export const projectCreationSchema = z.object({
   name: z.string().min(3, 'Project name must be at least 3 characters'),
+  code: z.string().min(3, "Code must be at least 3 characters").max(10),
   description: z.string().min(10, 'Description must be at least 10 characters'),
   version: z.string().min(1, 'Version is required'),
   website_url: z.string().url('Must be a valid URL').optional().or(z.literal('')),

--- a/ui/src/routes/workspace/projects/new/index.tsx
+++ b/ui/src/routes/workspace/projects/new/index.tsx
@@ -29,7 +29,7 @@ function CreateProject() {
         body: {
           name: values.name,
           description: values.description,
-          code: values.code || "",
+          code: values.code!,
           version: values.version,
           website_url: values.website_url || "",
           environments: values.environments || [],


### PR DESCRIPTION
### Description

In this PR I have fixed the issue of a project code in a new project, where by in the previous implementation the project code was was not generated even thought the UI form hard the field. Now when you add a project code during creation of a new project it is included.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #168 
