### PR TITLE
fix: duplicate testers on test plan assign

### DIFF
--- a/internal/services/tester.go
+++ b/internal/services/tester.go
@@ -40,8 +40,16 @@ func (s *testerServiceImpl) FindAll(ctx context.Context) ([]schema.Tester, error
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch project testers: %w", err)
 	}
+
+	seen := make(map[int64]bool)
 	testers := make([]schema.Tester, 0, len(projectTesters))
+
 	for _, tester := range projectTesters {
+		if seen[int64(tester.UserID)] {
+			continue
+		}
+		seen[int64(tester.UserID)] = true
+
 		testers = append(testers, schema.Tester{
 			UserID:      int64(tester.UserID),
 			ProjectID:   int64(tester.ProjectID),
@@ -97,8 +105,15 @@ func (s *testerServiceImpl) FindByProjectID(ctx context.Context, projectID int64
 		return nil, fmt.Errorf("failed to get tester IDs for project %d: %w", projectID, err)
 	}
 
+	seen := make(map[int64]bool)
+
 	testers := make([]schema.Tester, 0, len(projectTesters))
 	for _, tester := range projectTesters {
+		if seen[int64(tester.UserID)] {
+			continue
+		}
+		seen[int64(tester.UserID)] = true
+
 		testers = append(testers, schema.Tester{
 			UserID:      int64(tester.UserID),
 			ProjectID:   int64(tester.ProjectID),


### PR DESCRIPTION
### Description

In this PR I have fixed the issue of duplicate testers on the assign to test plan list.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes #170 
