### PR TITLE
fix:placeholder info description on assigning testcases to plan

### DIFF
--- a/ui/src/routes/(project)/projects/$projectId/test-cases/$testCaseId/index.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/test-cases/$testCaseId/index.tsx
@@ -242,7 +242,7 @@ function ViewTestCase() {
               <Alert.Indicator />
               <Alert.Content>
                 <Alert.Description>
-                  A test case can belong to only one test plan.
+                  A test case can belong to more than one test plan.
                 </Alert.Description>
               </Alert.Content>
             </Alert.Root>


### PR DESCRIPTION
### Description

In this PR I have updated the placeholder info description assigning test cases to a test plan, it previously said "a test case can only belong to one test plan" which is not true.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #223 
