### PR TITLE
feat:navigate to test plan from inbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ production.yml
 /uploads/
 node_modules/
 ui/src/routeTree.gen.ts
+archive-jqPOyq
 
 *.exe
 *.log

--- a/ui/src/routes/workspace/test-cases/inbox/$testCaseId/index.tsx
+++ b/ui/src/routes/workspace/test-cases/inbox/$testCaseId/index.tsx
@@ -6,6 +6,7 @@ import {
   Container,
   Heading,
   Menu,
+  Flex,
   Text,
   Textarea,
 } from "@chakra-ui/react";
@@ -159,9 +160,12 @@ function TestCaseInboxItem() {
 
     return (
     <Box>
-      <Heading size="lg" color="fg.heading">
-        {tc.title}
-      </Heading>
+      <Flex alignItems="center" justifyContent="space-between">
+        <Heading size="lg" color="fg.heading">
+          {tc.title}
+        </Heading>
+        <Button size="sm" variant="solid" colorPalette="brand" onClick={() => navigate({ to: `/projects/${tc.project_id}/test-plans/${tc.test_plan_id}/` })}>Go to Test Plan</Button>
+      </Flex>
       <Menu.Root>
         <Menu.Trigger asChild>
           <Button size="sm" variant="outline" colorPalette="brand">

--- a/ui/src/routes/workspace/test-cases/inbox/route.tsx
+++ b/ui/src/routes/workspace/test-cases/inbox/route.tsx
@@ -206,4 +206,3 @@ function TestCasePageInbox() {
 
 
 
-


### PR DESCRIPTION
### Description

In this PR I added a button in the inbox test case execute page, so that a user can navigate to the test case test plan easily.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #233 
