### PR TITLE
fix:remove the import from google sheets tab

### DIFF
--- a/ui/src/routes/(project)/projects/$projectId/test-cases/index.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/test-cases/index.tsx
@@ -217,10 +217,6 @@ export default function ListProjectTestCases() {
           onChange={handleFileChange}
         />
 
-        <Button colorPalette="success" size={"sm"}>
-          Import from Google Sheets
-        </Button>
-
         <ButtonGroup>
           <IconButton
             aria-label="List view"

--- a/ui/src/routes/workspace/test-cases/index.tsx
+++ b/ui/src/routes/workspace/test-cases/index.tsx
@@ -108,9 +108,7 @@ function TestCasePage() {
           <Link to="/workspace/test-cases/new">
             <Button colorPalette="brand">Create New</Button>
           </Link>
-          <Button colorPalette="success">Import from Excel</Button>
-          <Button colorPalette="success">Import from Google Sheets</Button>
-        </HStack>
+          <Button colorPalette="success">Import from Excel</Button>        </HStack>
       </Flex>
 
       <AppDataTable<TestCase, TestCaseListResponse>


### PR DESCRIPTION
### Description

In this PR I have removed the import from google sheets button from the test cases list

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #235 
