### PR TITLE
fix:modify the overview route

### DIFF
--- a/ui/src/components/app-sidebar.tsx
+++ b/ui/src/components/app-sidebar.tsx
@@ -28,6 +28,8 @@ import { findProjectsQueryOptions } from "@/data/queries/projects";
 import { Avatar } from "./ui/avatar";
 import { useAuth } from "@/context/AuthContext";
 import { THEME_OPTIONS, useColorMode } from "./ui/color-mode";
+import { Route as ProjectOverviewRoute } from "@/routes/(project)/projects/$projectId/overview";
+import { MainLinkItems, ProjectLinkItems } from "@/lib/navigation";
 
 interface NavLinkProps {
   item: NavItem;
@@ -122,7 +124,7 @@ const ContextSwitcher = ({
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
-  const projectMatch = location.pathname.match(/^\/projects\/([^/]+)/);
+  const projectMatch = location.pathname.match(/^\/projects\/([^/]+)(?:\/overview)?/);
   const activeProjectId = projectMatch?.[1];
   const activeProject = activeProjectId
     ? projects.find((project) => String(project.id) === activeProjectId)
@@ -278,7 +280,10 @@ const ContextSwitcher = ({
                       key={project.id}
                       value={`project-${project.id}`}
                       onClick={() =>
-                        navigate({ to: `/projects/${project.id}` })
+                        navigate({ 
+                          to: ProjectOverviewRoute.to,
+                          params: { projectId: String(project.id) }
+                        })
                       }
                       borderRadius="md"
                       bg={isActive ? "bg.subtle" : "transparent"}
@@ -390,6 +395,8 @@ const NavLink: React.FC<NavLinkProps> = ({ item, expanded }) => {
 const NavLinkItem = ({ item }: { item: NavItem }) => {
   const { isCollapsed } = useSidebar();
   const location = useLocation();
+  const projectMatch = location.pathname.match(/^\/projects\/([^/]+)/);
+  const projectId = projectMatch?.[1];
   const isActive =
     location.pathname === item.path ||
     location.pathname.startsWith(item.path + "/");
@@ -414,7 +421,7 @@ const NavLinkItem = ({ item }: { item: NavItem }) => {
       }}
       transition="all 0.2s"
     >
-      <Link to={item.path}>
+      <Link to={item.path} params={projectId ? { projectId } : undefined}>
         {item.icon && (
           <Icon
             fontSize="16"
@@ -444,11 +451,15 @@ interface SidebarProps extends BoxProps {
   header?: ReactNode;
 }
 
-const SidebarContent = ({ items, header, ...rest }: SidebarProps) => {
+const SidebarContent = ({ header, ...rest }: SidebarProps) => {
   const { isCollapsed } = useSidebar();
+  const location = useLocation();
+  const inProject = location.pathname.startsWith("/projects/");
   const visibleItems = useMemo(
-    () => items.filter((item) => !HIDDEN_PATHS.has(item.path)),
-    [items],
+    () => (inProject ? ProjectLinkItems : MainLinkItems).filter(
+      (item) => !HIDDEN_PATHS.has(item.path)
+    ),
+    [inProject]
   );
 
   const groupedItems = useMemo(() => {

--- a/ui/src/lib/navigation.ts
+++ b/ui/src/lib/navigation.ts
@@ -7,8 +7,11 @@ import {
   FiSettings,
   FiDatabase,
   FiInbox,
+  FiFileText,
+  FiList,
 } from "react-icons/fi";
 import { IconType } from "react-icons";
+import { Route as ProjectOverviewRoute } from "@/routes/(project)/projects/$projectId/overview";
 
 export interface NavItem {
   name: string;
@@ -26,4 +29,17 @@ export const MainLinkItems: NavItem[] = [
   { path: "/workspace/users", name: "Users", icon: FiUser },
   { path: "/workspace/settings", name: "Settings", icon: FiSettings },
   { path: "/logout", name: "Logout", icon: FiLogOut },
+];
+
+// Project‑level links
+export const ProjectLinkItems: NavItem[] = [
+  { path: ProjectOverviewRoute.to, name: "Overview", icon: FiHome }, 
+  { path: "/projects/$projectId/test-cases", name: "Test Cases", icon: FiFileText },
+  { path: "/projects/$projectId/test-plans", name: "Test Plans", icon: FiList },
+  { path: "/projects/$projectId/features", name: "Features/Modules", icon: FiDatabase },
+  { path: "/projects/$projectId/testers", name: "Testers", icon: FiUsers },
+  { path: "/projects/$projectId/reports", name: "Reports", icon: FiFileText },
+  { path: "/projects/$projectId/insights", name: "Insights", icon: FiFileText },
+  { path: "/projects/$projectId/settings", name: "Settings", icon: FiSettings },
+  { path: "/projects/$projectId/environments", name: "Environments", icon: FiDatabase },
 ];

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -35,7 +35,6 @@ import { Route as WorkspaceTestCasesNewIndexRouteImport } from './routes/workspa
 import { Route as WorkspaceProjectsNewIndexRouteImport } from './routes/workspace/projects/new/index'
 import { Route as WorkspaceOrganizationsNewIndexRouteImport } from './routes/workspace/organizations/new/index'
 import { Route as WorkspaceOrganizationsIdIndexRouteImport } from './routes/workspace/organizations/$id/index'
-import { Route as projectProjectsProjectIdIndexRouteImport } from './routes/(project)/projects/$projectId/index'
 import { Route as WorkspaceUsersViewUserIDRouteImport } from './routes/workspace/users/view/$userID'
 import { Route as WorkspaceTestCasesInboxSuggestRouteImport } from './routes/workspace/test-cases/inbox/suggest'
 import { Route as appUsersUserIDEditRouteImport } from './routes/(app)/users/$userID/edit'
@@ -48,6 +47,7 @@ import { Route as projectProjectsProjectIdTestPlansIndexRouteImport } from './ro
 import { Route as projectProjectsProjectIdTestCasesIndexRouteImport } from './routes/(project)/projects/$projectId/test-cases/index'
 import { Route as projectProjectsProjectIdSettingsIndexRouteImport } from './routes/(project)/projects/$projectId/settings/index'
 import { Route as projectProjectsProjectIdReportsIndexRouteImport } from './routes/(project)/projects/$projectId/reports/index'
+import { Route as projectProjectsProjectIdOverviewIndexRouteImport } from './routes/(project)/projects/$projectId/overview/index'
 import { Route as projectProjectsProjectIdInsightsIndexRouteImport } from './routes/(project)/projects/$projectId/insights/index'
 import { Route as projectProjectsProjectIdEnvironmentsIndexRouteImport } from './routes/(project)/projects/$projectId/environments/index'
 import { Route as projectProjectsProjectIdFeaturesIndexRouteImport } from './routes/(project)/projects/$projectId/Features/index'
@@ -205,12 +205,6 @@ const WorkspaceOrganizationsIdIndexRoute =
     path: '/organizations/$id/',
     getParentRoute: () => WorkspaceRouteRoute,
   } as any)
-const projectProjectsProjectIdIndexRoute =
-  projectProjectsProjectIdIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => projectProjectsProjectIdRouteRoute,
-  } as any)
 const WorkspaceUsersViewUserIDRoute =
   WorkspaceUsersViewUserIDRouteImport.update({
     id: '/users/view/$userID',
@@ -280,6 +274,12 @@ const projectProjectsProjectIdReportsIndexRoute =
   projectProjectsProjectIdReportsIndexRouteImport.update({
     id: '/reports/',
     path: '/reports/',
+    getParentRoute: () => projectProjectsProjectIdRouteRoute,
+  } as any)
+const projectProjectsProjectIdOverviewIndexRoute =
+  projectProjectsProjectIdOverviewIndexRouteImport.update({
+    id: '/overview/',
+    path: '/overview/',
     getParentRoute: () => projectProjectsProjectIdRouteRoute,
   } as any)
 const projectProjectsProjectIdInsightsIndexRoute =
@@ -421,7 +421,6 @@ export interface FileRoutesByFullPath {
   '/users/$userID/edit': typeof appUsersUserIDEditRoute
   '/workspace/test-cases/inbox/suggest': typeof WorkspaceTestCasesInboxSuggestRoute
   '/workspace/users/view/$userID': typeof WorkspaceUsersViewUserIDRoute
-  '/projects/$projectId/': typeof projectProjectsProjectIdIndexRoute
   '/workspace/organizations/$id/': typeof WorkspaceOrganizationsIdIndexRoute
   '/workspace/organizations/new/': typeof WorkspaceOrganizationsNewIndexRoute
   '/workspace/projects/new/': typeof WorkspaceProjectsNewIndexRoute
@@ -436,6 +435,7 @@ export interface FileRoutesByFullPath {
   '/projects/$projectId/Features/': typeof projectProjectsProjectIdFeaturesIndexRoute
   '/projects/$projectId/environments/': typeof projectProjectsProjectIdEnvironmentsIndexRoute
   '/projects/$projectId/insights/': typeof projectProjectsProjectIdInsightsIndexRoute
+  '/projects/$projectId/overview/': typeof projectProjectsProjectIdOverviewIndexRoute
   '/projects/$projectId/reports/': typeof projectProjectsProjectIdReportsIndexRoute
   '/projects/$projectId/settings/': typeof projectProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/test-cases/': typeof projectProjectsProjectIdTestCasesIndexRoute
@@ -459,6 +459,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/workspace': typeof WorkspaceRouteRouteWithChildren
   '/': typeof appIndexRoute
+  '/projects/$projectId': typeof projectProjectsProjectIdRouteRouteWithChildren
   '/workspace/test-cases/inbox': typeof WorkspaceTestCasesInboxRouteRouteWithChildren
   '/workspace/testers/invite': typeof WorkspaceTestersInviteRoute
   '/test-plans': typeof appTestPlansIndexRoute
@@ -479,7 +480,6 @@ export interface FileRoutesByTo {
   '/users/$userID/edit': typeof appUsersUserIDEditRoute
   '/workspace/test-cases/inbox/suggest': typeof WorkspaceTestCasesInboxSuggestRoute
   '/workspace/users/view/$userID': typeof WorkspaceUsersViewUserIDRoute
-  '/projects/$projectId': typeof projectProjectsProjectIdIndexRoute
   '/workspace/organizations/$id': typeof WorkspaceOrganizationsIdIndexRoute
   '/workspace/organizations/new': typeof WorkspaceOrganizationsNewIndexRoute
   '/workspace/projects/new': typeof WorkspaceProjectsNewIndexRoute
@@ -494,6 +494,7 @@ export interface FileRoutesByTo {
   '/projects/$projectId/Features': typeof projectProjectsProjectIdFeaturesIndexRoute
   '/projects/$projectId/environments': typeof projectProjectsProjectIdEnvironmentsIndexRoute
   '/projects/$projectId/insights': typeof projectProjectsProjectIdInsightsIndexRoute
+  '/projects/$projectId/overview': typeof projectProjectsProjectIdOverviewIndexRoute
   '/projects/$projectId/reports': typeof projectProjectsProjectIdReportsIndexRoute
   '/projects/$projectId/settings': typeof projectProjectsProjectIdSettingsIndexRoute
   '/projects/$projectId/test-cases': typeof projectProjectsProjectIdTestCasesIndexRoute
@@ -540,7 +541,6 @@ export interface FileRoutesById {
   '/(app)/users/$userID/edit': typeof appUsersUserIDEditRoute
   '/workspace/test-cases/inbox/suggest': typeof WorkspaceTestCasesInboxSuggestRoute
   '/workspace/users/view/$userID': typeof WorkspaceUsersViewUserIDRoute
-  '/(project)/projects/$projectId/': typeof projectProjectsProjectIdIndexRoute
   '/workspace/organizations/$id/': typeof WorkspaceOrganizationsIdIndexRoute
   '/workspace/organizations/new/': typeof WorkspaceOrganizationsNewIndexRoute
   '/workspace/projects/new/': typeof WorkspaceProjectsNewIndexRoute
@@ -555,6 +555,7 @@ export interface FileRoutesById {
   '/(project)/projects/$projectId/Features/': typeof projectProjectsProjectIdFeaturesIndexRoute
   '/(project)/projects/$projectId/environments/': typeof projectProjectsProjectIdEnvironmentsIndexRoute
   '/(project)/projects/$projectId/insights/': typeof projectProjectsProjectIdInsightsIndexRoute
+  '/(project)/projects/$projectId/overview/': typeof projectProjectsProjectIdOverviewIndexRoute
   '/(project)/projects/$projectId/reports/': typeof projectProjectsProjectIdReportsIndexRoute
   '/(project)/projects/$projectId/settings/': typeof projectProjectsProjectIdSettingsIndexRoute
   '/(project)/projects/$projectId/test-cases/': typeof projectProjectsProjectIdTestCasesIndexRoute
@@ -601,7 +602,6 @@ export interface FileRouteTypes {
     | '/users/$userID/edit'
     | '/workspace/test-cases/inbox/suggest'
     | '/workspace/users/view/$userID'
-    | '/projects/$projectId/'
     | '/workspace/organizations/$id/'
     | '/workspace/organizations/new/'
     | '/workspace/projects/new/'
@@ -616,6 +616,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/Features/'
     | '/projects/$projectId/environments/'
     | '/projects/$projectId/insights/'
+    | '/projects/$projectId/overview/'
     | '/projects/$projectId/reports/'
     | '/projects/$projectId/settings/'
     | '/projects/$projectId/test-cases/'
@@ -639,6 +640,7 @@ export interface FileRouteTypes {
   to:
     | '/workspace'
     | '/'
+    | '/projects/$projectId'
     | '/workspace/test-cases/inbox'
     | '/workspace/testers/invite'
     | '/test-plans'
@@ -659,7 +661,6 @@ export interface FileRouteTypes {
     | '/users/$userID/edit'
     | '/workspace/test-cases/inbox/suggest'
     | '/workspace/users/view/$userID'
-    | '/projects/$projectId'
     | '/workspace/organizations/$id'
     | '/workspace/organizations/new'
     | '/workspace/projects/new'
@@ -674,6 +675,7 @@ export interface FileRouteTypes {
     | '/projects/$projectId/Features'
     | '/projects/$projectId/environments'
     | '/projects/$projectId/insights'
+    | '/projects/$projectId/overview'
     | '/projects/$projectId/reports'
     | '/projects/$projectId/settings'
     | '/projects/$projectId/test-cases'
@@ -719,7 +721,6 @@ export interface FileRouteTypes {
     | '/(app)/users/$userID/edit'
     | '/workspace/test-cases/inbox/suggest'
     | '/workspace/users/view/$userID'
-    | '/(project)/projects/$projectId/'
     | '/workspace/organizations/$id/'
     | '/workspace/organizations/new/'
     | '/workspace/projects/new/'
@@ -734,6 +735,7 @@ export interface FileRouteTypes {
     | '/(project)/projects/$projectId/Features/'
     | '/(project)/projects/$projectId/environments/'
     | '/(project)/projects/$projectId/insights/'
+    | '/(project)/projects/$projectId/overview/'
     | '/(project)/projects/$projectId/reports/'
     | '/(project)/projects/$projectId/settings/'
     | '/(project)/projects/$projectId/test-cases/'
@@ -949,13 +951,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceOrganizationsIdIndexRouteImport
       parentRoute: typeof WorkspaceRouteRoute
     }
-    '/(project)/projects/$projectId/': {
-      id: '/(project)/projects/$projectId/'
-      path: '/'
-      fullPath: '/projects/$projectId/'
-      preLoaderRoute: typeof projectProjectsProjectIdIndexRouteImport
-      parentRoute: typeof projectProjectsProjectIdRouteRoute
-    }
     '/workspace/users/view/$userID': {
       id: '/workspace/users/view/$userID'
       path: '/users/view/$userID'
@@ -1038,6 +1033,13 @@ declare module '@tanstack/react-router' {
       path: '/reports'
       fullPath: '/projects/$projectId/reports/'
       preLoaderRoute: typeof projectProjectsProjectIdReportsIndexRouteImport
+      parentRoute: typeof projectProjectsProjectIdRouteRoute
+    }
+    '/(project)/projects/$projectId/overview/': {
+      id: '/(project)/projects/$projectId/overview/'
+      path: '/overview'
+      fullPath: '/projects/$projectId/overview/'
+      preLoaderRoute: typeof projectProjectsProjectIdOverviewIndexRouteImport
       parentRoute: typeof projectProjectsProjectIdRouteRoute
     }
     '/(project)/projects/$projectId/insights/': {
@@ -1290,7 +1292,6 @@ const projectProjectsProjectIdTestPlansTestPlanIDRouteWithChildren =
   )
 
 interface projectProjectsProjectIdRouteRouteChildren {
-  projectProjectsProjectIdIndexRoute: typeof projectProjectsProjectIdIndexRoute
   projectProjectsProjectIdFeaturesCreateFeatureModuleFormRoute: typeof projectProjectsProjectIdFeaturesCreateFeatureModuleFormRoute
   projectProjectsProjectIdFeaturesEditFeatureModuleFormRoute: typeof projectProjectsProjectIdFeaturesEditFeatureModuleFormRoute
   projectProjectsProjectIdEnvironmentsEnvironmentIdRoute: typeof projectProjectsProjectIdEnvironmentsEnvironmentIdRoute
@@ -1300,6 +1301,7 @@ interface projectProjectsProjectIdRouteRouteChildren {
   projectProjectsProjectIdFeaturesIndexRoute: typeof projectProjectsProjectIdFeaturesIndexRoute
   projectProjectsProjectIdEnvironmentsIndexRoute: typeof projectProjectsProjectIdEnvironmentsIndexRoute
   projectProjectsProjectIdInsightsIndexRoute: typeof projectProjectsProjectIdInsightsIndexRoute
+  projectProjectsProjectIdOverviewIndexRoute: typeof projectProjectsProjectIdOverviewIndexRoute
   projectProjectsProjectIdReportsIndexRoute: typeof projectProjectsProjectIdReportsIndexRoute
   projectProjectsProjectIdSettingsIndexRoute: typeof projectProjectsProjectIdSettingsIndexRoute
   projectProjectsProjectIdTestCasesIndexRoute: typeof projectProjectsProjectIdTestCasesIndexRoute
@@ -1315,7 +1317,6 @@ interface projectProjectsProjectIdRouteRouteChildren {
 
 const projectProjectsProjectIdRouteRouteChildren: projectProjectsProjectIdRouteRouteChildren =
   {
-    projectProjectsProjectIdIndexRoute: projectProjectsProjectIdIndexRoute,
     projectProjectsProjectIdFeaturesCreateFeatureModuleFormRoute:
       projectProjectsProjectIdFeaturesCreateFeatureModuleFormRoute,
     projectProjectsProjectIdFeaturesEditFeatureModuleFormRoute:
@@ -1334,6 +1335,8 @@ const projectProjectsProjectIdRouteRouteChildren: projectProjectsProjectIdRouteR
       projectProjectsProjectIdEnvironmentsIndexRoute,
     projectProjectsProjectIdInsightsIndexRoute:
       projectProjectsProjectIdInsightsIndexRoute,
+    projectProjectsProjectIdOverviewIndexRoute:
+      projectProjectsProjectIdOverviewIndexRoute,
     projectProjectsProjectIdReportsIndexRoute:
       projectProjectsProjectIdReportsIndexRoute,
     projectProjectsProjectIdSettingsIndexRoute:

--- a/ui/src/routes/(project)/projects/$projectId/overview/index.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/overview/index.tsx
@@ -1,29 +1,36 @@
-import { createFileRoute, Link} from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { Box, Flex, Button, Heading, Text, Stack, Spinner } from "@chakra-ui/react";
 import { useProjectQuery } from "@/services/ProjectService";
 
-export const Route = createFileRoute("/(project)/projects/$projectId/")({
+// Route for the Overview page
+export const Route = createFileRoute("/(project)/projects/$projectId/overview/")({
   component: ViewProject,
+});
+
+// Redirect route: when someone visits /projects/:projectId, send them to /overview
+export const RedirectRoute = createFileRoute("/(project)/projects/$projectId")({
+  beforeLoad: ({ params }) => {
+    return { redirect: Route.to, params }; 
+  },
 });
 
 function ViewProject() {
   const { projectId } = Route.useParams();
   const { data: project, isLoading, error } = useProjectQuery(projectId!);
-  
+
   if (isLoading) return <Spinner color="brand.solid" />;
   if (error) return <Text color="fg.error">Error loading project.</Text>;
-  // const matchRoute = useMatchRoute();
 
   const navItems = [
-    { label: "Summary", path: `/projects/$projectId` },
-    { label: "Test Cases", path: `/projects/$projectId/test-cases` },
-    { label: "Test Plans", path: `/projects/$projectId/test-plans` },
-    { label: "Features/Modules", path: `/projects/$projectId/Features` },
-    { label: "Testers", path: `/projects/$projectId/testers` },
-    { label: "Reports", path: `/projects/$projectId/reports` },
-    { label: "Insights", path: `/projects/$projectId/insights` },
-    { label: "Settings", path: `/projects/$projectId/settings` },
-    {label: "Environments", path: `/projects/$projectId/environments`},
+    { label: "Summary", path: Route.to },
+    { label: "Test Cases", path: "/projects/$projectId/test-cases" },
+    { label: "Test Plans", path: "/projects/$projectId/test-plans" },
+    { label: "Features/Modules", path: "/projects/$projectId/Features" },
+    { label: "Testers", path: "/projects/$projectId/testers" },
+    { label: "Reports", path: "/projects/$projectId/reports" },
+    { label: "Insights", path: "/projects/$projectId/insights" },
+    { label: "Settings", path: "/projects/$projectId/settings" },
+    { label: "Environments", path: "/projects/$projectId/environments" },
   ];
 
   return (
@@ -37,14 +44,9 @@ function ViewProject() {
         overflowX="auto"
       >
         {navItems.map((item) => {
-          const isActive = false;
-          // TODO: const isActive = matchRoute({item.path.replace("$projectId", projectId));
+          const isActive = false; // TODO: use matchRoute for active state
           return (
-            <Link
-              key={item.label}
-              to={item.path}
-              params={{ projectId }}
-            >
+            <Link key={item.label} to={item.path} params={{ projectId }}>
               <Button
                 variant={isActive ? "solid" : "ghost"}
                 colorPalette="brand"
@@ -64,7 +66,7 @@ function ViewProject() {
         <Text mb={4} color="fg.subtle">
           Here’s how the testing process works in this project:
         </Text>
-         <Stack gap={3}>
+        <Stack gap={3}>
           <Text>• Create <strong>Test Cases</strong> for the project.</Text>
           <Text>• Add those test cases into a <strong>Test Plan</strong>.</Text>
           <Text>• Assign users to execute the test cases in the plan.</Text>

--- a/ui/src/routes/workspace/projects/index.tsx
+++ b/ui/src/routes/workspace/projects/index.tsx
@@ -29,6 +29,7 @@ import { Link } from "@tanstack/react-router";
 import { toaster } from "@/components/ui/toaster";
 import $api from "@/lib/api/query";
 import { useMemo, useState } from "react";
+import { Route as ProjectOverviewRoute } from "@/routes/(project)/projects/$projectId/overview";
 
 type ProjectRecord = {
   id?: number;
@@ -311,7 +312,7 @@ function ProjectsPage() {
 
                     <Flex wrap="wrap" gap={2}>
                       {hasId ? (
-                        <Link to="/projects/$projectId" params={{ projectId }}>
+                        <Link to={ProjectOverviewRoute.to} params={{ projectId }}>
                           <Button
                             variant="outline"
                             colorPalette="brand"


### PR DESCRIPTION
### Description

In this PR, I have modified the route path to Overview, so that it doesn't end with projectId, but projectId/overview

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #237 
