### PR TITLE
feat:add a date picker on new testplan form

### DIFF
--- a/ui/src/data/forms/test-plan-field-configs.ts
+++ b/ui/src/data/forms/test-plan-field-configs.ts
@@ -19,7 +19,7 @@ export const testPlanCreationFields: FieldConfig[] = [
     helperText: 'Choose the type of testing this plan covers',
     options: testPlanKindOptions, 
   }),
-  createFieldConfig('start_at', 'Start Date', 'text', {
+  createFieldConfig('start_at', 'Start Date', 'date', {
     placeholder: 'YYYY-MM-DD',
     helperText: 'When the test plan should start',
   }),
@@ -28,11 +28,11 @@ export const testPlanCreationFields: FieldConfig[] = [
     helperText: 'Select environment for this test plan',
     options: [],
   }),
-  createFieldConfig('scheduled_end_at', 'Scheduled End Date', 'text', {
+  createFieldConfig('scheduled_end_at', 'Scheduled End Date', 'date', {
     placeholder: 'YYYY-MM-DD',
     helperText: 'When the test plan is scheduled to end',
   }),
-  createFieldConfig('closed_at', 'Closed Date', 'text', {
+  createFieldConfig('closed_at', 'Closed Date', 'date', {
     placeholder: 'YYYY-MM-DD (optional)',
     helperText: 'When the test plan was actually closed (optional)',
   }),
@@ -50,15 +50,15 @@ export const testPlanUpdateFields: FieldConfig[] = [
     helperText: 'Choose the type of testing this plan covers',
     options: testPlanKindOptions,
   }),
-  createFieldConfig('start_at', 'Start Date', 'text', {
+  createFieldConfig('start_at', 'Start Date', 'date', {
     placeholder: 'YYYY-MM-DD',
     helperText: 'When the test plan should start',
   }),
-  createFieldConfig('scheduled_end_at', 'Scheduled End Date', 'text', {
+  createFieldConfig('scheduled_end_at', 'Scheduled End Date', 'date', {
     placeholder: 'YYYY-MM-DD',
     helperText: 'When the test plan is scheduled to end',
   }),
-  createFieldConfig('closed_at', 'Closed Date', 'text', {
+  createFieldConfig('closed_at', 'Closed Date', 'date', {
     placeholder: 'YYYY-MM-DD (optional)',
     helperText: 'When the test plan was actually closed (optional)',
   }),


### PR DESCRIPTION
### Description

In this PR I have added a date picker to the Create new test plan form on following fields:
1. Start Date
2. Scheduled End Date
3. Closed Date

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #239 
