### PR TITLE
fix:refresh-inbox after recording test results

### DIFF
--- a/ui/src/routes/workspace/test-cases/inbox/$testCaseId/index.tsx
+++ b/ui/src/routes/workspace/test-cases/inbox/$testCaseId/index.tsx
@@ -14,6 +14,8 @@ import { IconChevronDown } from "@tabler/icons-react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   findTestCaseInboxByIdQueryOptions,
+  findTestCaseInboxQueryOptions,
+  findTestCaseSummaryQueryOptions,
 } from "@/data/queries/test-cases";
 import {
   useSuspenseQuery,
@@ -99,10 +101,14 @@ function TestCaseInboxItem() {
       setResultText("");
       setNotesText("");
 
-      queryClient.invalidateQueries({ queryKey: ["testCases", "inbox"] });
-      queryClient.invalidateQueries({ queryKey: ["testCases", "inbox", testCaseId] });
-      queryClient.invalidateQueries({ queryKey: ["testCases", "summary"] });
-    },
+      queryClient.invalidateQueries(findTestCaseInboxQueryOptions(false));
+      queryClient.invalidateQueries(findTestCaseSummaryQueryOptions);
+      queryClient.invalidateQueries(findTestCaseInboxByIdQueryOptions(testCaseId));
+
+      // Optional: force refetch for instant UI update
+      queryClient.refetchQueries(findTestCaseInboxQueryOptions(false));
+      queryClient.refetchQueries(findTestCaseSummaryQueryOptions);
+        },
     onError: () => {
       toaster.create({
         title: "Error",


### PR DESCRIPTION
### Description

I have updated the inbox recording form, so that after recording the result the figures should instantly get updated on test cases summary badges.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #249 
