### PR TITLE
chore: set qatarina server to always run migrations on startup

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/golang-malawi/qatarina/internal/api"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +12,14 @@ var serverCmd = &cobra.Command{
 	Short: "Starts the HelpAside server daemon",
 	Long:  `Starts the HelpAside server daemon`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Run migrations on server startup unless the environment variable is set
+		if _, ok := os.LookupEnv("QATARINA_DISABLE_MIGRATIONS_ON_STARTUP"); !ok {
+			err := migrateCmd.RunE(cmd, []string{"up"})
+			if err != nil {
+				return err
+			}
+		}
+
 		apiServer := api.NewAPI(qatarinaConfig)
 		// var err error
 		// apiServer.RiverClient, err = worker.StartRiverWorker(qatarinaConfig)


### PR DESCRIPTION
…

### Description

Set qatarina server to always run migrations unless QATARINA_DISABLE_MIGRATIONS_ON_STARTUP is set

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Add any extra context, screenshots, or information reviewers should be aware of.
