### PR TITLE
chore: fixed the linting issues that were initially caused by route params

### DIFF
--- a/ui/src/routes/(project)/projects/$projectId/test-cases/$testCaseId/edit.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/test-cases/$testCaseId/edit.tsx
@@ -127,7 +127,7 @@ function EditTestCase() {
     }
       return field;
     }),
-    [scriptValidationStatus, scriptValidationMessage, handleRunnerChange]
+    [scriptValidationStatus, scriptValidationMessage, handleRunnerChange, projectId]
   );
 
   const validateAttachedScript = async (file: File) => {

--- a/ui/src/routes/(project)/projects/$projectId/test-cases/new/index.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/test-cases/new/index.tsx
@@ -161,7 +161,7 @@ function NewTestCases() {
         }
         return field;
       }),
-    [scriptValidationStatus, scriptValidationMessage, handleRunnerChange],
+    [scriptValidationStatus, scriptValidationMessage, handleRunnerChange, params.projectId],
   );
 
   async function handleSubmit(values: TestCaseCreationFormData) {


### PR DESCRIPTION
### Description
Resolved `react-hooks/exhaustive-deps` warnings in the test case create and edit
routes. The `useMemo` building the form `fields` array referenced `projectId`
(via `params.projectId` in the create route) inside the `SelectFeatureModule`
custom component, but didn't include it in the dependency array. Added it to
both:

- `src/routes/(project)/projects/$projectId/test-cases/new/index.tsx`
- `src/routes/(project)/projects/$projectId/test-cases/$testCaseId/edit.tsx`

No functional change expected, since `projectId` doesn't change during the
component's lifetime — this just makes the lint rule pass and keeps the memo
correct if that assumption ever changes.

@zikani03

