### PR TITLE
feat(batch assign test cases to test plan): add batch endpoint to assign multiple test cases to multiple users

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -132,6 +132,8 @@ func (api *API) routes() {
 		testPlansV1.Post("/:testPlanID/close", apiv1.CloseTestPlan(api.TestPlansService, api.logger))
 		testPlansV1.Post("/:testPlanID/environment", apiv1.ChangeEnvironment(api.TestPlansService, api.logger))
 
+		testPlansV1.Post("/:testPlanID/test-cases/batch", apiv1.BatchAssignTestCasesToPlan(api.TestPlansService, api.logger))
+		
 		commentsV1 := testPlansV1.Group("/:testPlanID/comments")
 		{
 			commentsV1.Get("", apiv1.ListTestPlanComments(api.TestPlansService, api.logger))

--- a/internal/api/v1/testplans.go
+++ b/internal/api/v1/testplans.go
@@ -533,7 +533,7 @@ func BatchAssignTestCasesToPlan(testPlanService services.TestPlanService, logger
         _, err := testPlanService.BatchAssignTestCasesToPlan(c.Context(), request)
         if err != nil {
             logger.Error(loggedmodule.ApiTestPlans, "failed to process request", "error", err)
-            return problemdetail.ServerErrorProblem(c, "failed to process request")
+            return problemdetail.BadRequest(c, "failed to process request")
         }
 
         return c.JSON(fiber.Map{

--- a/internal/api/v1/testplans.go
+++ b/internal/api/v1/testplans.go
@@ -512,3 +512,32 @@ func ConvertCommentToTestCase(testPlanService services.TestPlanService, logger l
 		return c.JSON(fiber.Map{"message": "converted to test case", "test_case_id": newID})
 	}
 }
+
+
+func BatchAssignTestCasesToPlan(testPlanService services.TestPlanService, logger logging.Logger) fiber.Handler {
+    return func(c *fiber.Ctx) error {
+        request := new(schema.BatchAssignTestCasesToPlanRequest)
+        if validationErrors, err := common.ParseBodyThenValidate(c, request); err != nil {
+            if validationErrors {
+                return problemdetail.ValidationErrors(c, "invalid data in request", err)
+            }
+            logger.Error(loggedmodule.ApiTestPlans, "failed to parse request data", "error", err)
+            return problemdetail.BadRequest(c, "failed to parse data in request")
+        }
+
+        planID, _ := common.ParseIDFromCtx(c, "testPlanID")
+        if request.PlanID != planID {
+            return problemdetail.BadRequest(c, "plan_id in request body and param do not match")
+        }
+
+        _, err := testPlanService.BatchAssignTestCasesToPlan(c.Context(), request)
+        if err != nil {
+            logger.Error(loggedmodule.ApiTestPlans, "failed to process request", "error", err)
+            return problemdetail.ServerErrorProblem(c, "failed to process request")
+        }
+
+        return c.JSON(fiber.Map{
+            "message": "Test cases created and assigned",
+        })
+    }
+}

--- a/internal/schema/testplan.go
+++ b/internal/schema/testplan.go
@@ -34,6 +34,13 @@ type AssignTestsToPlanRequest struct {
 	PlannedTests []TestCaseAssignment `json:"planned_tests" validate:"required,min=1,max=100"`
 }
 
+type BatchAssignTestCasesToPlanRequest struct {
+    ProjectID   int64    `json:"project_id" validate:"required"`
+    PlanID      int64    `json:"test_plan_id" validate:"required"`
+    TestCaseIDs []string `json:"test_case_ids" validate:"required,min=1,max=100"`
+    UserIDs     []int64  `json:"user_ids" validate:"required,min=1,max=100"`
+}
+
 type TestPlanResponseItem struct {
 	ID              int64                  `json:"id"`
 	ProjectID       int32                  `json:"project_id"`

--- a/internal/schema/testruns.go
+++ b/internal/schema/testruns.go
@@ -76,7 +76,7 @@ func ParseIssuesFromMarkdownList(userID int64, testDate time.Time, content strin
 			IsClosed:       false,
 			TestedOn:       testDate,
 			ActualResult:   entryNormalized,
-			ExpectedResult: fmt.Sprintf("Expected different behavior"),
+			ExpectedResult: "Expected different behavior",
 			State:          dbsqlc.TestRunStateFailed,
 		}
 		testRuns = append(testRuns, item)

--- a/internal/schema/testruns.go
+++ b/internal/schema/testruns.go
@@ -64,6 +64,7 @@ func ParseIssuesFromMarkdownList(userID int64, testDate time.Time, content strin
 
 	testRuns := make([]CommitTestRunResult, 0)
 	for _, entry := range items {
+		
 
 		entryNormalized := strings.Replace(entry, "-", "", 1)
 		entryNormalized = strings.Replace(entryNormalized, "*", "", 1)

--- a/internal/services/testplan.go
+++ b/internal/services/testplan.go
@@ -29,6 +29,8 @@ type TestPlanService interface {
 	CreateComment(ctx context.Context, req *schema.CreateComment) (*schema.CommentResponseItem, error)
 	DeleteComment(ctx context.Context, commentID string) error
 	ConvertCommentToTestCase(ctx context.Context, commentID string) (string, error)
+
+	BatchAssignTestCasesToPlan(context.Context, *schema.BatchAssignTestCasesToPlanRequest) (*dbsqlc.GetTestPlanRow, error)
 }
 
 var _ TestPlanService = &testPlanService{}
@@ -366,4 +368,30 @@ func (t *testPlanService) ConvertCommentToTestCase(ctx context.Context, commentI
 		return "", err
 	}
 	return id.String(), nil
+}
+
+func (t *testPlanService) BatchAssignTestCasesToPlan(ctx context.Context, request *schema.BatchAssignTestCasesToPlanRequest) (*dbsqlc.GetTestPlanRow, error) {
+	testPlan, err := t.queries.GetTestPlan(ctx, request.PlanID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, testCaseIDStr := range request.TestCaseIDs {
+		testCaseID, err := uuid.Parse(testCaseIDStr)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, uid := range request.UserIDs {
+			if err := t.queries.AddTestCaseToPlan(ctx, dbsqlc.AddTestCaseToPlanParams{
+				TestPlanID:   request.PlanID,
+				TestCaseID:   testCaseID,
+				AssignedToID: uid,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &testPlan, nil
 }

--- a/internal/services/testplan.go
+++ b/internal/services/testplan.go
@@ -100,10 +100,7 @@ func (t *testPlanService) FindAll(ctx context.Context) ([]schema.TestPlanRespons
 
 	var enriched []schema.TestPlanResponseItem
 	for _, plan := range plans {
-		// Count assigned test cases
 		cases, _ := t.queries.ListTestCasesByPlan(ctx, plan.ID)
-
-		// Get run stats
 		runStats, _ := t.queries.GetTestPlanRunStats(ctx, sql.NullInt32{Int32: int32(plan.ID), Valid: true})
 
 		enriched = append(enriched, schema.TestPlanResponseItem{
@@ -156,26 +153,55 @@ func (t *testPlanService) FindAllByTestPlanID(ctx context.Context, testPlanID in
 	return t.queries.ListTestRunsByPlan(ctx, sql.NullInt32{Int32: testPlanID, Valid: true})
 }
 
-// AddTestCaseToPlan implements TestPlanService.
-func (t *testPlanService) AddTestCaseToPlan(ctx context.Context, request *schema.AssignTestsToPlanRequest) (*dbsqlc.GetTestPlanRow, error) {
-	testPlan, err := t.queries.GetTestPlan(ctx, request.PlanID)
+type testCaseAssignment struct {
+	TestCaseID   uuid.UUID
+	AssignedToID int64
+}
+
+func (t *testPlanService) assignTestCases(ctx context.Context, planID int64, assignments []testCaseAssignment) (*dbsqlc.GetTestPlanRow, error) {
+	testPlan, err := t.queries.GetTestPlan(ctx, planID)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, assignedTestCase := range request.PlannedTests {
-		for _, uid := range assignedTestCase.UserIDs {
-			if err := t.queries.AddTestCaseToPlan(ctx, dbsqlc.AddTestCaseToPlanParams{
-				TestPlanID:   request.PlanID,
-				TestCaseID:   uuid.MustParse(assignedTestCase.TestCaseID),
-				AssignedToID: uid,
-			}); err != nil {
-				return nil, err
-			}
+	for _, a := range assignments {
+		if err := t.queries.AddTestCaseToPlan(ctx, dbsqlc.AddTestCaseToPlanParams{
+			TestPlanID:   planID,
+			TestCaseID:   a.TestCaseID,
+			AssignedToID: a.AssignedToID,
+		}); err != nil {
+			return nil, err
 		}
 	}
 
 	return &testPlan, nil
+}
+
+// AddTestCaseToPlan implements TestPlanService.
+func (t *testPlanService) AddTestCaseToPlan(ctx context.Context, request *schema.AssignTestsToPlanRequest) (*dbsqlc.GetTestPlanRow, error) {
+	var assignments []testCaseAssignment
+	for _, pt := range request.PlannedTests {
+		tcID := uuid.MustParse(pt.TestCaseID)
+		for _, uid := range pt.UserIDs {
+			assignments = append(assignments, testCaseAssignment{TestCaseID: tcID, AssignedToID: uid})
+		}
+	}
+	return t.assignTestCases(ctx, request.PlanID, assignments)
+}
+
+// BatchAssignTestCasesToPlan implements TestPlanService.
+func (t *testPlanService) BatchAssignTestCasesToPlan(ctx context.Context, request *schema.BatchAssignTestCasesToPlanRequest) (*dbsqlc.GetTestPlanRow, error) {
+	var assignments []testCaseAssignment
+	for _, tcIDStr := range request.TestCaseIDs {
+		tcID, err := uuid.Parse(tcIDStr)
+		if err != nil {
+			return nil, err
+		}
+		for _, uid := range request.UserIDs {
+			assignments = append(assignments, testCaseAssignment{TestCaseID: tcID, AssignedToID: uid})
+		}
+	}
+	return t.assignTestCases(ctx, request.PlanID, assignments)
 }
 
 func (t *testPlanService) DeleteByID(ctx context.Context, id int64) error {
@@ -195,13 +221,11 @@ func (t *testPlanService) GetOneTestPlan(ctx context.Context, id int64) (*schema
 		return nil, fmt.Errorf("failed to load test plan: %w", err)
 	}
 
-	// Get assigned cases
 	cases, err := t.queries.ListTestCasesByPlan(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test cases for plan %d: %w", id, err)
 	}
 
-	// Get run statistics
 	runStats, err := t.queries.GetTestPlanRunStats(ctx, sql.NullInt32{Int32: int32(id), Valid: true})
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test run statistics for plan %d: %w", id, err)
@@ -233,7 +257,6 @@ func (t *testPlanService) GetOneTestPlan(ctx context.Context, id int64) (*schema
 		TestCases:       []schema.TestCaseResponseItem{},
 	}
 
-	// Build response test cases with multiple assigned testers
 	for _, tc := range cases {
 		response.TestCases = append(response.TestCases, schema.TestCaseResponseItem{
 			ID:                   tc.ID.String(),
@@ -368,30 +391,4 @@ func (t *testPlanService) ConvertCommentToTestCase(ctx context.Context, commentI
 		return "", err
 	}
 	return id.String(), nil
-}
-
-func (t *testPlanService) BatchAssignTestCasesToPlan(ctx context.Context, request *schema.BatchAssignTestCasesToPlanRequest) (*dbsqlc.GetTestPlanRow, error) {
-	testPlan, err := t.queries.GetTestPlan(ctx, request.PlanID)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, testCaseIDStr := range request.TestCaseIDs {
-		testCaseID, err := uuid.Parse(testCaseIDStr)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, userID := range request.UserIDs {
-			if err := t.queries.AddTestCaseToPlan(ctx, dbsqlc.AddTestCaseToPlanParams{
-				TestPlanID:   request.PlanID,
-				TestCaseID:   testCaseID,
-				AssignedToID: userID,
-			}); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return &testPlan, nil
 }

--- a/internal/services/testplan.go
+++ b/internal/services/testplan.go
@@ -382,11 +382,11 @@ func (t *testPlanService) BatchAssignTestCasesToPlan(ctx context.Context, reques
 			return nil, err
 		}
 
-		for _, uid := range request.UserIDs {
+		for _, userID := range request.UserIDs {
 			if err := t.queries.AddTestCaseToPlan(ctx, dbsqlc.AddTestCaseToPlanParams{
 				TestPlanID:   request.PlanID,
 				TestCaseID:   testCaseID,
-				AssignedToID: uid,
+				AssignedToID: userID,
 			}); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
### Description

Adds a new endpoint, `POST /v1/test-plans/:testPlanID/test-cases/batch`, that assigns
a set of test cases to a set of users in one request.

The existing `POST /v1/test-plans/:testPlanID/test-cases` endpoint already supports
batching, but requires a separate `user_ids` array per test case in the payload
(`planned_tests: [{ test_case_id, user_ids }]`), which means the same set of users has
to be repeated for every test case when you just want "these test cases, assigned to
these users."

This PR adds a new endpoint.
```json
{
  "project_id": 1,
  "test_plan_id": 2,
  "test_case_ids": ["uuid-1", "uuid-2"],
  "user_ids": [1, 2]
}
```

This assigns every test case in `test_case_ids` to every user in `user_ids` (a full
cross product) via a nested loop, reusing the existing `AddTestCaseToPlan` sqlc query
per (test_case, user) pair.

### Checklist
Please review and check all that apply before requesting a review:
- [x] I have updated api documentation (applicable if api has been changed)
- [x] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---
### Additional Notes (optional)

- New route, new schema types, new service method — the existing `AssignTestsToPlan`
  endpoint and its request/response shape are unchanged, so no breaking changes for
  any existing consumers.