### PR TITLE
fix:reflesh project test case list page while deleting

### DIFF
--- a/ui/src/routes/(project)/projects/$projectId/test-cases/index.tsx
+++ b/ui/src/routes/(project)/projects/$projectId/test-cases/index.tsx
@@ -342,7 +342,6 @@ export default function ListProjectTestCases() {
                     await queryClient.invalidateQueries({
                       queryKey: ["get", "/v1/projects/{projectID}/test-cases"],
                     });
-                    window.location.href = `/projects/${projectId}/test-cases`;
                   } catch (err: any) {
                     toaster.error({
                       title: t("test_cases.delete.error"),


### PR DESCRIPTION
### Description

In this PR i have fixed the issue with project test case list, where by it was reloading the whole page, when a user tried to delete a test case.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

### Additional Notes (optional)

Closes: #301 
