### PR TITLE
fix:disable closed test cases from sheetview

### DIFF
--- a/ui/src/routes/workspace/test-cases/inbox/sheetView.tsx
+++ b/ui/src/routes/workspace/test-cases/inbox/sheetView.tsx
@@ -535,7 +535,7 @@ const TestCaseRow = React.forwardRef<HTMLTableRowElement, TestCaseRowProps>(
     const lastRun = runsList.find((r: any) => r.test_case_id === tc.id);
 
     return (
-      <Table.Row ref={ref} bg={rowBg} _hover={{ bg: "blue.50" }}>
+      <Table.Row ref={ref} bg={rowBg} _hover={{ bg: "blue.50" }} opacity={tc.is_closed ? 0.5 : 1}>
         {/* Code Column */}
         <Table.Cell border="1px solid" borderColor="gray.200" py={1} px={2}>
           <Text fontWeight="medium" fontSize="xs" truncate title={tc.code || `#${tc.id}`}>


### PR DESCRIPTION
### Description

In this PR I have fixed the bug, about disabling closed test cases in the sheet view and use the toggle checkbox to view them.

### Checklist

Please review and check all that apply before requesting a review:

- [ ] I have updated api documentation (applicable if api has been changed)
- [ ] I have generated the API docs for the backend (`swag init --v3.1`) (if applicable)
- [ ] I have generated the API client for the frontend (`cd ui && npm run gen:api`) (if applicable)

---

Closes: #292 

Add any extra context, screenshots, or information reviewers should be aware of.
